### PR TITLE
Fix drag and drop on windows

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -110,7 +110,7 @@ void MainWindow::dropEvent(QDropEvent *event)
      if (event->mimeData()->hasUrls()) {
          foreach (QUrl url, event->mimeData()->urls()) {
              qDebug() << url;
-             do_open (url.path ());
+             do_open(url.toLocalFile());
          }
      }
 }


### PR DESCRIPTION
`url.path()` dodawał do początku ścieżki przed nazwą dysku **/** przez co pliki nie wczytywały się poprawnie. Używając `url.toLocalFile()` udało mi się poprawić ten błąd.
