### PR TITLE
Changing default delay to 200

### DIFF
--- a/settingsdialog.cpp
+++ b/settingsdialog.cpp
@@ -97,6 +97,7 @@ int SettingsDialog::exec()
     ui.selectColorPB->setPalette(QPalette(tmpColor = selectionColor()));
     ui.invalidColorPB->setPalette(QPalette(tmpInvalidColor = invalidColor()));
     ui.executionColorPB->setPalette(QPalette(tmpExecutionColor = executionColor()));
+    ui.executionDelaySB->setValue(SettingsDialog::executionSleep());
 
     return QDialog::exec();
 }
@@ -153,7 +154,7 @@ void SettingsDialog::accept()
 
 int SettingsDialog::executionSleep()
 {
-    return appSettings->value("execution-sleep", 1000).toInt();
+    return appSettings->value("execution-sleep", 200).toInt();
 }
 
 void SettingsDialog::setExecutionSleep(int v)

--- a/settingsdialog.ui
+++ b/settingsdialog.ui
@@ -287,7 +287,7 @@
             <number>100</number>
            </property>
            <property name="value" >
-            <number>1000</number>
+            <number>200</number>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Changing default delay to 200 ms, as well as fixing not showing proper value read from QSettings when Settings windows is being opened.

Fixes #14 
