### PR TITLE
Fixes in instructionwizard

### DIFF
--- a/instructionwizard.cpp
+++ b/instructionwizard.cpp
@@ -24,8 +24,7 @@ InstructionWizardDialog::InstructionWizardDialog(MainWindow *parent)
     instructionEditor = new ::InstructionEditorForm(ui.contentsFrame);
     ui.contentsFrame->layout()->addWidget(instructionEditor);
 
-    ui.nextButton->setShortcut(QKeySequence(Qt::Key_PageDown));
-    ui.finishButton->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_PageDown));
+    ui.nextButton->setShortcut(QKeySequence(Qt::Key_PageDown));    
 }
 
 void InstructionWizardDialog::on_prevButton_clicked()

--- a/instructionwizard.cpp
+++ b/instructionwizard.cpp
@@ -23,6 +23,9 @@ InstructionWizardDialog::InstructionWizardDialog(MainWindow *parent)
 
     instructionEditor = new ::InstructionEditorForm(ui.contentsFrame);
     ui.contentsFrame->layout()->addWidget(instructionEditor);
+
+    ui.nextButton->setShortcut(QKeySequence(Qt::Key_PageDown));
+    ui.finishButton->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_PageDown));
 }
 
 void InstructionWizardDialog::on_prevButton_clicked()
@@ -45,7 +48,7 @@ void InstructionWizardDialog::on_nextButton_clicked()
 
 void InstructionWizardDialog::on_instructionReady(bool isReady)
 {
-    ui.finishButton->setEnabled(isReady);
+    ui.finishButton->setEnabled(isReady);    
 }
 
 void InstructionWizardDialog::reset(NSScheme *s)

--- a/instructionwizard.ui
+++ b/instructionwizard.ui
@@ -188,13 +188,6 @@
    <item>
     <layout class="QHBoxLayout">
      <item>
-      <widget class="QPushButton" name="helpButton">
-       <property name="text">
-        <string>Help</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QPushButton" name="cancelPB">
        <property name="text">
         <string>Cancel</string>

--- a/instructionwizard.ui
+++ b/instructionwizard.ui
@@ -250,6 +250,9 @@
        <property name="text">
         <string>Finish</string>
        </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
Removes unnecessary "help" button, adds the shortcut for the "next page" and sets "finish" as default button, so the Enter key works.